### PR TITLE
Provide a better dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ apifant-editor/
 .idea/
 .github/
 build/
-spectral-package/
 
 .gitignore
 .docker-compose.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,9 @@ USER 1001
 
 COPY --chown=1001:1001  valigator.json $HOME/valigator.json
 
+# for some reason adding everything with /* moves all files up to the spectral directory...
+COPY --chown=1001:1001 spectral-package/v5 .
+COPY --chown=1001:1001 spectral-package/v10 .
+COPY --chown=1001:1001 spectral-package/spectral spectral
+
 CMD [ "valigator" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       dockerfile: Dockerfile
       args:
         - GOARCH=arm64
+    environment:
+      DEVMODE: 1
     ports:
       - 8081:8081
     healthcheck:

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module apifant-valigator
 go 1.18
 
 require github.com/google/uuid v1.3.0
+
+require github.com/rs/cors v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
+github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=


### PR DESCRIPTION
This allows direct access to the valigator api when executed in a local setup, which enables access from a dev environment of the apifant-editor.

The cors headers will only be added if the `DEVMODE` environment variable is explicitely set so this shouldn't change anything for the real deployment.